### PR TITLE
Fixed GPDatabase.php failing due to usage of libphutil deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A couple of things that describe graphp:
 * DB API is designed for fast performance. No implicit joins or other magic, but expressive enough for nice readable code.
 * No CLI needed (but supported for cron and tests).
 * All classes are loaded on demand when used for the first time.
-* PHP 5.5+
+* PHP 5.6+
 
 A simple example:
 

--- a/config/general.php
+++ b/config/general.php
@@ -18,7 +18,7 @@ return [
   'view_404'      => '',
   'layout_404'    => '',
 
-  'app_folder'    => 'sample_app',
+  'app_folder'    => 'app',
 
   // This will automatically drop the DB before the first view is rendered
   'disallow_view_db_access' => false,

--- a/config/general.php
+++ b/config/general.php
@@ -18,7 +18,7 @@ return [
   'view_404'      => '',
   'layout_404'    => '',
 
-  'app_folder'    => 'app',
+  'app_folder'    => 'sample_app',
 
   // This will automatically drop the DB before the first view is rendered
   'disallow_view_db_access' => false,

--- a/graphp/core/GPDatabase.php
+++ b/graphp/core/GPDatabase.php
@@ -117,11 +117,13 @@ class GPDatabase extends GPObject {
       return [];
     }
     $type_fragment = $type ? 'AND type = %d;' : ';';
-    return vqueryfx_all(
+    $args = array_filter([$ids, $type]);
+    array_unshift(
+      $args,
       $this->getConnection(),
-      'SELECT * FROM node WHERE id IN (%Ld) '.$type_fragment,
-      array_filter([$ids, $type])
+      'SELECT * FROM node WHERE id IN (%Ld) '.$type_fragment
     );
+    return call_user_func_array('queryfx_all', $args);
   }
 
   public function getNodeIDsByTypeData($type, array $data) {
@@ -167,12 +169,14 @@ class GPDatabase extends GPObject {
     if (!$parts) {
       return;
     }
-    vqueryfx(
+    $args = $values;
+    array_unshift(
+      $args,
       $this->getConnection(),
       'INSERT INTO node_data (node_id, type, data) VALUES '.
-      implode(',', $parts) . ' ON DUPLICATE KEY UPDATE data = VALUES(data);',
-      $values
+      implode(',', $parts) . ' ON DUPLICATE KEY UPDATE data = VALUES(data);'
     );
+    call_user_func_array('queryfx', $args);
   }
 
   private function getEdgeParts(GPNode $from_node, array $array_of_arrays) {
@@ -192,12 +196,14 @@ class GPDatabase extends GPObject {
     if (!$parts) {
       return;
     }
-    vqueryfx(
+    $args = $values;
+    array_unshift(
+      $args,
       $this->getConnection(),
       'INSERT IGNORE INTO edge (from_node_id, to_node_id, type) VALUES '.
-      implode(',', $parts) . ';',
-      $values
+      implode(',', $parts) . ';'
     );
+    call_user_func_array('queryfx', $args);
   }
 
   public function deleteEdges(GPNode $from_node, array $array_of_arrays) {
@@ -205,12 +211,14 @@ class GPDatabase extends GPObject {
     if (!$parts) {
       return;
     }
-    vqueryfx(
+    $args = $values;
+    array_unshift(
+      $args,
       $this->getConnection(),
       'DELETE FROM edge WHERE (from_node_id, to_node_id, type) IN ('.
-      implode(',', $parts) . ');',
-      $values
+      implode(',', $parts) . ');'
     );
+    call_user_func_array('queryfx', $args);
   }
 
   public function deleteAllEdges(GPNode $node, array $edge_types) {
@@ -235,12 +243,14 @@ class GPDatabase extends GPObject {
     if (!$parts) {
       return;
     }
-    vqueryfx(
+    $args = $values;
+    array_unshift(
+      $args,
       $this->getConnection(),
       'DELETE FROM edge WHERE ('.$col.', type) IN ('.
-      implode(',', $parts) . ');',
-      $values
+      implode(',', $parts) . ');'
     );
+    call_user_func_array('queryfx', $args);
   }
 
   public function getConnectedIDs(
@@ -270,13 +280,14 @@ class GPDatabase extends GPObject {
       $args[] = $offset;
       $args[] = $limit;
     }
-    $results = vqueryfx_all(
+    array_unshift(
+      $args,
       $this->getConnection(),
       'SELECT from_node_id, to_node_id, type FROM edge '.
       'WHERE from_node_id IN (%Ld) AND type IN (%Ld) ORDER BY updated DESC'.
-      ($limit === null ? '' : ' LIMIT %d, %d').';',
-      $args
+      ($limit === null ? '' : ' LIMIT %d, %d').';'
     );
+    $results = queryfx_all($args);
     $ordered = [];
     foreach ($results as $result) {
       if (!array_key_exists($result['from_node_id'], $ordered)) {

--- a/graphp/core/GPDatabase.php
+++ b/graphp/core/GPDatabase.php
@@ -287,7 +287,7 @@ class GPDatabase extends GPObject {
       'WHERE from_node_id IN (%Ld) AND type IN (%Ld) ORDER BY updated DESC'.
       ($limit === null ? '' : ' LIMIT %d, %d').';'
     );
-    $results = queryfx_all($args);
+    $results = call_user_func_array('queryfx_all', $args);
     $ordered = [];
     foreach ($results as $result) {
       if (!array_key_exists($result['from_node_id'], $ordered)) {


### PR DESCRIPTION
vqueryfx and vqueryfx_all where being used in graphp/core/GPDatabase.php but they were removed from libphutil with:
    
    https://secure.phabricator.com/D12566
    
For the fix array_unshift and call_user_func_array where used similarly to how vqueryfx and vqueryfx_all used them. It is kind of verbose, but the other considered options involved other non desired consequences: For example using argument unpacking would have resulted in shorter and cleaner code, but then increasing the required PHP version to be 5.6+ for graphp