### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/graphp/utils/STRUtils.php
+++ b/graphp/utils/STRUtils.php
@@ -21,7 +21,7 @@ class STRUtils {
     // search backwards starting from haystack length characters from the end
     return
       $needle === "" ||
-      strrpos($haystack, $needle, - strlen($haystack)) !== FALSE;
+      strrpos($haystack, $needle, - strlen($haystack)) !== false;
   }
 
   public static function endsWith($haystack, $needle) {
@@ -30,7 +30,7 @@ class STRUtils {
       $needle === "" ||
       (
         ($temp = strlen($haystack) - strlen($needle)) >= 0 &&
-        strpos($haystack, $needle, $temp) !== FALSE
+        strpos($haystack, $needle, $temp) !== false
       );
   }
 


### PR DESCRIPTION
Hi, I've changed some PHP keywords to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!